### PR TITLE
only search for users with icinga_email attribute set

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -24,7 +24,7 @@ include_recipe "apache2::mod_rewrite"
 include_recipe "icinga::plugins_package"
 include_recipe "icinga::core_source"
 
-sysadmins = search(:users, "groups:#{node['icinga']['sysadmin']}")
+sysadmins = search(:users, "groups:#{node['icinga']['sysadmin']} AND icinga_email:*")
 nodes = search(:node, "hostname:[* TO *] AND chef_environment:#{node.chef_environment}")
 
 if nodes.empty?


### PR DESCRIPTION
this saves `chef-client` from dying with:

``` ruby
Chef::Mixin::Template::TemplateError (undefined method `[]' for nil:NilClass) on line #29:

27:   use          default-contact
28:   contact_name <%= a['id'] %>
29:   email        <%= a['icinga']['email'] %>
30: }
31:
```
