### PR TITLE
Use latest release with fixed ssl

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,5 @@
-default['icinga']['version'] = "1.4.2"
-default['icinga']['checksum'] = "506022493295bda95aa2514bfdc3196063ed936655bc60068f61543504b42aa6"
+default['icinga']['version'] = "1.8.1"
+default['icinga']['checksum'] = "3d02d80bdefc2518ab8517be6930a518b77747e0243fa594731fb1f95dbab916"
 default['icinga']['prefix'] = "/usr/local/icinga"
 
 default['icinga']['sysadmin_email'] = "root@localhost"

--- a/recipes/core_source.rb
+++ b/recipes/core_source.rb
@@ -55,7 +55,8 @@ bash "compile-install-icinga" do
     ./configure \
       --with-icinga-user=#{iuser} --with-icinga-group=#{igroup} \
       --with-command-user=#{iuser} --with-command-group=#{igroup} \
-      --prefix #{node['icinga']['prefix']} --enable-idoutils --enable-ssl && \
+      --with-ssl-lib=/usr/lib/${HOSTTYPE}-linux-gnu/ --enable-ssl \
+      --prefix #{node['icinga']['prefix']} --enable-idoutils && \
     make all && \
     make fullinstall
   EOH

--- a/recipes/core_source.rb
+++ b/recipes/core_source.rb
@@ -52,8 +52,10 @@ bash "compile-install-icinga" do
   code <<-EOH
     tar -zxf icinga-#{version}.tar.gz && \
     cd icinga-#{version} && \
-    ./configure --with-icinga-user=#{iuser} --with-icinga-group=#{igroup} \
-    --with-command-user=#{iuser} --with-command-group=#{igroup} --prefix #{node['icinga']['prefix']} --enable-idoutils --enable-ssl && \
+    ./configure \
+      --with-icinga-user=#{iuser} --with-icinga-group=#{igroup} \
+      --with-command-user=#{iuser} --with-command-group=#{igroup} \
+      --prefix #{node['icinga']['prefix']} --enable-idoutils --enable-ssl && \
     make all && \
     make fullinstall
   EOH

--- a/recipes/core_source.rb
+++ b/recipes/core_source.rb
@@ -52,7 +52,7 @@ bash "compile-install-icinga" do
   code <<-EOH
     tar -zxf icinga-#{version}.tar.gz && \
     cd icinga-#{version} && \
-    ./configure --with-icinga-user=#{iuser} --with-icinga-group=#{igroup} --with-nagios-user=#{iuser} --with-nagios-group=#{igroup} \
+    ./configure --with-icinga-user=#{iuser} --with-icinga-group=#{igroup} \
     --with-command-user=#{iuser} --with-command-group=#{igroup} --prefix #{node['icinga']['prefix']} --enable-idoutils --enable-ssl && \
     make all && \
     make fullinstall


### PR DESCRIPTION
Hi,

intentionally this PR should only fix `./configure ---enable-ssl` which seems to be broken on ubuntu (at least on >= 12.04 x64). But, as 1.4.2 is quite outdated, I've upgraded the default version and removed some outdated / already removed configure flags too. I hope you're fine with that - even if this PR is not as "atomic" as it could be.

Best regards, Michael
