### PR TITLE
Do not install recommended packages - we don't want nagios3

### DIFF
--- a/recipes/plugins_package.rb
+++ b/recipes/plugins_package.rb
@@ -22,5 +22,9 @@
    package pkg
 end
 
-package "nagios-nrpe-plugin"
+package "nagios-nrpe-plugin" do
+  # Required so we don't install nagios3 (and thus apache2+php5) - see http://packages.ubuntu.com/de/precise/nagios-nrpe-plugin
+  options "--no-install-recommends"
+  action :install
+end
 


### PR DESCRIPTION
Ubuntu/Apt installs the recommanded packages along when installing `nagios-nrpe-plugin`. This installs `nagios3`, which in turn installs `apache2`.

This breaks our systems which use `nginx`. This PR prevents the installation of recommended packages for `nagios-nrpe-plugin`.
