### PR TITLE
Add hostgroups for all configured roles instead of using the run list.

### DIFF
--- a/templates/default/hosts.cfg.erb
+++ b/templates/default/hosts.cfg.erb
@@ -6,7 +6,7 @@ define host {
   use server
   address <%= n['ipaddress'] %>
   host_name <%= n['hostname'] %>
-<% if n.run_list.roles.nil? || n.run_list.roles.length == 0 -%>
+<% if n.roles.nil? || n.roles.length == 0 -%>
   hostgroups all
 <% else -%>
   hostgroups <%= n.roles.to_a.join(",") %>

--- a/templates/default/hosts.cfg.erb
+++ b/templates/default/hosts.cfg.erb
@@ -9,7 +9,7 @@ define host {
 <% if n.run_list.roles.nil? || n.run_list.roles.length == 0 -%>
   hostgroups all
 <% else -%>
-  hostgroups <%= n.run_list.roles.to_a.join(",") %>
+  hostgroups <%= n.roles.to_a.join(",") %>
 <% end -%>
 }
 


### PR DESCRIPTION
Using the run list leaves out role dependencies, like our base role. As we
want to configure specific checks based on them, we have to include them
in the list of hostgroups.
