### PR TITLE
Default checks role config

### DIFF
--- a/templates/default/services.cfg.erb
+++ b/templates/default/services.cfg.erb
@@ -21,7 +21,7 @@ define service {
 # Uncomment if you're using Munin
 #define service {
 #    service_description Munin Client
-#    hostgroup_name      all
+#    hostgroup_name      <%= node['icinga']['default_checks_server_role'] || 'all' %>
 #    check_command       check_tcp!4949
 #    use                 default-service
 #}
@@ -37,35 +37,35 @@ define service {
 
 define service {
     service_description Free Space All Disks
-    hostgroup_name      all
+    hostgroup_name      <%= node['icinga']['default_checks_server_role'] || 'all' %>
     check_command       check_all_disks
     use                 default-service
 }
 
 define service {
     service_description Load Average
-    hostgroup_name      all
+    hostgroup_name      <%= node['icinga']['default_checks_server_role'] || 'all' %>
     check_command       check_load
     use                 default-service
 }
 
 define service {
     service_description Free Memory
-    hostgroup_name      all
+    hostgroup_name      <%= node['icinga']['default_checks_server_role'] || 'all' %>
     check_command       check_mem
     use                 default-service
 }
 
 define service {
     service_description SSH
-    hostgroup_name      all
+    hostgroup_name      <%= node['icinga']['default_checks_server_role'] || 'all' %>
     check_command       check_ssh
     use                 default-service
 }
 
 define service {
     service_description Processes
-    hostgroup_name      all
+    hostgroup_name      <%= node['icinga']['default_checks_server_role'] || 'all' %>
     check_command       check_local_procs
     use                 default-service
 }

--- a/templates/default/services.cfg.erb
+++ b/templates/default/services.cfg.erb
@@ -4,7 +4,7 @@
 
 define service {
     use                 default-service
-    host_name           *
+    hostgroup_name      <%= node['icinga']['default_checks_server_role'] || 'all' %>
     service_description ping
     check_command       check_ping!200.0,20%!500.0,60%
 }


### PR DESCRIPTION
Made the name of the role for default checks configurable. Allows having hosts without default checks. Like monitoring a non self hosted service.
