### PR TITLE
Allow empty hostgroups by default

### DIFF
--- a/templates/default/icinga.cfg.erb
+++ b/templates/default/icinga.cfg.erb
@@ -118,3 +118,4 @@ debug_verbosity=1
 debug_file=<%= node['icinga']['state_dir'] %>/icinga.debug
 max_debug_file_size=100000000
 event_profiling_enabled=0
+allow_empty_hostgroup_assignment=1


### PR DESCRIPTION
This allows the first Chef-managed icinga server to boot properly.

Not sure why, but a new node's run_list doesn't appear to be populated on the Chef server until the node has successfully run Chef with that run_list. Unfortunately, this is a chicken-and-egg problem unless empty hostgroups are allowed -- the node['icinga']['server_role'] list will be empty (unless another server with that role is already running), causing Icinga startup to fail, causing Chef to fail, causing the run_list to remain unpopulated.

Option docs:
http://docs.icinga.org/latest/en/configmain.html#configmain-allow_empty_hostgroup_assignment
