### PR TITLE
Icinga client (NRPE) recipe

### DIFF
--- a/attributes/client.rb
+++ b/attributes/client.rb
@@ -1,0 +1,6 @@
+default[:icinga][:plugin_dir] = "/usr/lib/nagios/plugins"
+default[:icinga][:checks][:memory][:critical] = 150
+default[:icinga][:checks][:memory][:warning]  = 250
+default[:icinga][:checks][:load][:critical]   = "30,25,20"
+default[:icinga][:checks][:load][:warning]    = "15,15,10"
+default[:icinga][:checks][:smtp_host] = String.new

--- a/files/default/plugins/check_mem.sh
+++ b/files/default/plugins/check_mem.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+#
+# evaluate free system memory from Linux based systems
+#
+# Date: 2007-11-12
+# Author: Thomas Borger - ESG
+#
+# the memory check is done with following command line:
+# free -m | grep buffers/cache | awk '{ print $4 }'
+
+# get arguments
+
+while getopts 'w:c:hp' OPT; do
+  case $OPT in
+    w)  int_warn=$OPTARG;;
+    c)  int_crit=$OPTARG;;
+    h)  hlp="yes";;
+    p)  perform="yes";;
+    *)  unknown="yes";;
+  esac
+done
+
+# usage
+HELP="
+    usage: $0 [ -w value -c value -p -h ]
+
+    syntax:
+
+            -w --> Warning integer value
+            -c --> Critical integer value
+            -p --> print out performance data
+            -h --> print this help screen
+"
+
+if [ "$hlp" = "yes" -o $# -lt 1 ]; then
+  echo "$HELP"
+  exit 0
+fi
+
+# get free memory
+FMEM=`free -m | grep buffers/cache | awk '{ print $4 }'`
+
+# output with or without performance data
+if [ "$perform" = "yes" ]; then
+  OUTPUTP="free system memory: $FMEM MB | free memory="$FMEM"MB;$int_warn;$int_crit;0"
+else
+  OUTPUT="free system memory: $FMEM MB"
+fi
+
+if [ -n "$int_warn" -a -n "$int_crit" ]; then
+
+  err=0
+
+  if (( $FMEM <= $int_warn )); then
+    err=1
+  elif (( $FMEM <= $int_crit )); then
+    err=2
+  fi
+
+  if (( $err == 0 )); then
+
+    if [ "$perform" = "yes" ]; then
+      echo "MEM OK - $OUTPUTP"
+      exit "$err"
+    else
+      echo "MEM OK - $OUTPUT"
+      exit "$err"
+    fi
+
+  elif (( $err == 1 )); then
+    if [ "$perform" = "yes" ]; then
+      echo "MEM WARNING - $OUTPUTP"
+      exit "$err"
+    else
+      echo "MEM WARNING - $OUTOUT"
+      exit "$err"
+    fi
+
+  elif (( $err == 2 )); then
+    
+    if [ "$perform" = "yes" ]; then
+      echo "MEM CRITICAL - $OUTPUTP"
+      exit "$err"
+    else
+      echo "MEM CRITICAL - $OUTPUT"
+      exit "$err"
+    fi
+
+  fi
+  
+else
+  
+  echo "no output from plugin"
+  exit 3
+
+fi
+exit  
+

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -1,0 +1,60 @@
+#
+# Author:: Joshua Sierles <joshua@37signals.com>
+# Author:: Joshua Timberman <joshua@opscode.com>
+# Author:: Nathan Haneysmith <nathan@opscode.com>
+# Author:: Mike Babineau <michael.babineau@gmail.com>
+# Cookbook Name:: icinga
+# Attributes:: client
+#
+# Copyright 2009, 37signals
+# Copyright 2009-2010, Opscode, Inc
+# Copyright 2013, Mike Babineau
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+mon_host = Array.new
+
+search(:node, "role:#{node['icinga']['server_role']} AND chef_environment:#{node.chef_environment}") do |n|
+  mon_host << n['ipaddress']
+end
+
+%w{
+  nagios-nrpe-server
+  nagios-plugins
+  nagios-plugins-basic
+  nagios-plugins-standard
+}.each do |pkg|
+  package pkg
+end
+
+service "nagios-nrpe-server" do
+  action :enable
+  supports :restart => true, :reload => true
+end
+
+cookbook_file "/usr/lib/nagios/plugins/check_mem.sh" do
+  source "plugins/check_mem.sh"
+  owner "nagios"
+  group "nagios"
+  mode 0755
+end
+
+template "/etc/nagios/nrpe.cfg" do
+  source "nrpe.cfg.erb"
+  owner "nagios"
+  group "nagios"
+  mode "0644"
+  variables :mon_host => mon_host
+  notifies :restart, resources(:service => "nagios-nrpe-server")
+end

--- a/templates/default/nrpe.cfg.erb
+++ b/templates/default/nrpe.cfg.erb
@@ -1,0 +1,28 @@
+pid_file=/var/run/nrpe.pid
+server_port=5666
+nrpe_user=nagios
+nrpe_group=nagios
+dont_blame_nrpe=0
+debug=0
+command_timeout=60
+allowed_hosts=<%= @mon_host.join(',') %>
+
+command[check_users]=<%= node[:icinga][:plugin_dir] %>/check_users -w 20 -c 30
+command[check_load]=<%= node[:icinga][:plugin_dir] %>/check_load -w <%= node[:icinga][:checks][:load][:warning] %> -c <%= node[:icinga][:checks][:load][:critical] %>
+command[check_all_disks]=<%= node[:icinga][:plugin_dir] %>/check_disk -w 8% -c 5% -A -x /dev/shm -X nfs -i /boot
+command[check_zombie_procs]=<%= node[:icinga][:plugin_dir] %>/check_procs -w 5 -c 10 -s Z
+command[check_total_procs]=<%= node[:icinga][:plugin_dir] %>/check_procs -w 500 -c 800
+command[check_ntp_time]=<%= node[:icinga][:plugin_dir] %>/check_ntp_time -H us.pool.ntp.org -w 0.5 -c 1
+command[check_swap]=<%= node[:icinga][:plugin_dir] %>/check_swap -w '50%' -c '25%'
+command[check_mem]=<%= node[:icinga][:plugin_dir] %>/check_mem.sh -w <%= node[:icinga][:checks][:memory][:warning] %> -c <%= node[:icinga][:checks][:memory][:critical] %> -p
+command[check_chef_client]=<%= node[:icinga][:plugin_dir] %>/check_procs -w 1:2 -c 1:2 -C chef-client
+command[check_carbon_cache]=<%= node[:icinga][:plugin_dir] %>/check_procs -w 1:2 -c 1:2 -C "carbon-cache.py"
+command[check_smtp]=<%= node[:icinga][:plugin_dir] %>/check_smtp -H <%= node[:icinga][:checks][:smtp_host] %>
+command[check_nginx]=<%= node[:icinga][:plugin_dir] %>/check_procs -w 2:3 -c 1:5 -C nginx
+command[check_sphinx]=<%= node[:icinga][:plugin_dir] %>/check_procs -c 1:1 -C searchd
+#command[check_unicorn]=<%= node[:icinga][:plugin_dir] %>/check_procs -c 4:8 -C unicorn_rails
+#
+# memcached checks require cpan modules, "Cache::Memcached" and "Nagios::Plugins::Memcached"
+#command[check_memcached_response]=/usr/local/bin/check_memcached -H <%= node[:ipaddress] %> -w 3 -c 5
+#command[check_memcached_size]=/usr/local/bin/check_memcached -H <%= node[:ipaddress] %> --size-warning 60 --size-critical 80
+#command[check_memcached_hit]=/usr/local/bin/check_memcached -H <%= node[:ipaddress] %> --hit-warning 40 --hit-critical 20


### PR DESCRIPTION
I know you've got a separate NRPE cookbook, but I added a client recipe that includes automatic configuration of allowed_hosts via search (environment + "server_role"). It's based on the 37Signals/Opscode nagios::client recipe.

Some people like their cookbooks to provide both client- and server-side recipes. Your call on whether or not to include it :)

Tested on Ubuntu 12.04.
